### PR TITLE
Add UI Info Suite wild tree localization support

### DIFF
--- a/[CP] Cornucopia More Crops/data/wildtrees.json
+++ b/[CP] Cornucopia More Crops/data/wildtrees.json
@@ -44,7 +44,10 @@
 							"ItemId": "(O)Cornucopia_ChicleRubber",
 							"DaysUntilReady": 5
 						}
-					]
+					],
+					"CustomFields": {
+						"UIInfoSuite.ExtendedData/DisplayName": "{{i18n:Sapodilla_name}}"
+					}
 				}
 			}
 		}

--- a/[CP] Cornucopia More Flowers/data/wildtrees.json
+++ b/[CP] Cornucopia More Flowers/data/wildtrees.json
@@ -54,7 +54,10 @@
 							"ID": "Default",
 							"Result": "Deny",
 						}
-					]
+					],
+					"CustomFields": {
+						"UIInfoSuite.ExtendedData/DisplayName": "{{i18n:CorpseFlowerTree_name}}"
+					}
 				}
 			}
 		}

--- a/[CP] Cornucopia More Flowers/i18n/default.json
+++ b/[CP] Cornucopia More Flowers/i18n/default.json
@@ -212,6 +212,7 @@
   "Mail_HaleyRoyalJelly": "Hey @,^Gosh, can you believe it's summer already? By the way, I read something in a magazine that I wanted to tell you. Did you know that bees can sometimes make a special product called Royal Jelly? Apparently it's really sweet, buttery, and great for your skin. You just need to plant special flowers around them!^^Sunflowers are the best of course, but this article says you can use roses, or experiment with other \"royal\" flowers. Why don't you give it a try and tell me if it works?^   -Haley",
   "CorpseFlowerSeed_name": "Corpse Flower Seed",
   "CorpseFlowerSeed_description": "The seed of a stinking flower as large as a tree.",
+  "CorpseFlowerTree_name": "Corpse Flower",
   "CorpseFlowerPetal_name": "Corpse Flower Petal",
   "CorpseFlowerPetal_description": "A petal so large that it could be used as a blanket, if it didn't smell so horrible."
 }


### PR DESCRIPTION
Unlike Fruit Trees, Wild trees don't have any sort of fields dedicated to displaying a name.
It's easy enough to hardcode the base stardew trees for UI Info Suite, but once it gets to modded trees it's not practical to maintain my own translations of trees for every mod.
This PR adds a custom field allowing UI Info Suite 2 to read the name of the tree without keeping its own translation